### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. People listed below will be requested for review
+# when someone opens a pull request.
+@lmilbaum @fdegir @MarckK @gkunz @vikyol @tracymiranda @mjmckay @mgreau @majinghe @todaywasawesome


### PR DESCRIPTION
SIG members are added to CODEOWNERS file as the default owners for
everything in the repo.
Members listed in the file will be requested for review for PRs.