### PR TITLE
Document SIG Workstream Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Chairs and the TOC Sponsor of the SIG are
 
 SIG Software Supply Chain welcomes contributors who take part in the SIG to form workstreams to work on specific areas of interest in a more focused and structured way.
 
-Workstream governance is TBD.
+Workstream governance is [here](./docs/workstream-governance.md).
 
 ## Communication
 

--- a/docs/workstream-governance.md
+++ b/docs/workstream-governance.md
@@ -10,7 +10,7 @@ Workstreams should, at a regular cadence, share their progress with the rest of 
 
 ## Lifecycle
 
-Working groups are temporary in nature. They are formed to focus on specific goals and can be disbanded after reaching their goals. Upon formation, leads for the working group are choosen by the working group. When leads step down, they can be replaced by [lazy concensus](https://wiki.openoffice.org/wiki/Documentation/FAQ/ProjectLevel/CommunityQuestions/What_is_%22Lazy_Consensus%22%3F). However, working groups can also be disbanded if there is no longer a lead for the working group (within an 8 week grace period).
+Workstreams are temporary in nature. They are formed to focus on specific goals and can be archived after reaching their goals. Upon formation, leads for the workstreams are choosen by the workstream participants. When leads step down, they can be replaced by [lazy concensus](https://wiki.openoffice.org/wiki/Documentation/FAQ/ProjectLevel/CommunityQuestions/What_is_%22Lazy_Consensus%22%3F). However, working groups can also be disbanded if there is no longer a lead for the working group (within an 8 week grace period).
 
 ## Proposing a new Workstream
 
@@ -32,4 +32,4 @@ None
 
 ## Example Workstreams
 
-* [SIG Interoperability Events in CICD](https://github.com/cdfoundation/sig-interoperability/tree/main/workstreams/archived/events_in_cicd)
+* [SIG Interoperability Events in CICD](https://github.com/cdfoundation/sig-interoperability/tree/main/workstreams/archived/events_in_cicd) (*archived*)

--- a/docs/workstream-governance.md
+++ b/docs/workstream-governance.md
@@ -1,0 +1,35 @@
+# Software Supply Chain Workstreams
+
+## Overview and Motivations
+
+Project and user representatives who take part in the Software Supply Chain SIG are welcome to form a workstream to work on specific areas of interest in a more focused and structured way.
+
+The expectations from workstreams would vary depending on the area of focus. Workstreams could focus on collecting the state of things in a specific area from within the ecosystem and contribute that to the domain, or come up with a proposal to address some of the needs in a more structured way in order to socialize their ideas further and increase the awareness.
+
+Workstreams should, at a regular cadence, share their progress with the rest of the SIG. Workstreams could liase with the Software Supply Chain SIG to present ideas per area on CDF TOC level in order to gather feedback.
+
+## Lifecycle
+
+Working groups are temporary in nature. They are formed to focus on specific goals and can be disbanded after reaching their goals. Upon formation, leads for the working group are choosen by the working group. When leads step down, they can be replaced by [lazy concensus](https://wiki.openoffice.org/wiki/Documentation/FAQ/ProjectLevel/CommunityQuestions/What_is_%22Lazy_Consensus%22%3F). However, working groups can also be disbanded if there is no longer a lead for the working group (within an 8 week grace period).
+
+## Proposing a new Workstream
+
+We welcome proposals for new workstreams. 🎉
+
+Proposals for new workstreams can be made via a [PR](https://github.com/cdfoundation/sig-software-supply-chain/pulls) on the Software Supply Chain SIG repo, for discussion and feedback.
+
+Please create a directory in the [workstreams directory](../workstreams/) with a README providing information about the workstream's focus, goals, membership, and meeting logistics.
+
+Add your proposal, and a link to your PR, to our [meeting notes](https://hackmd.io/MX4W9EE0RBeO3xfJ9wDi_Q) as an agenda item to discuss at the next SIG meeting. Discussion during the SIG is a great way to gather further feedback and support and attract additional collaborators.
+
+## Current Workstreams
+
+Current workstreams can be found in the [workstreams directory](../workstreams/).
+
+## Archived Workstreams
+
+None
+
+## Example Workstreams
+
+* [SIG Interoperability Events in CICD](https://github.com/cdfoundation/sig-interoperability/tree/main/workstreams/archived/events_in_cicd)


### PR DESCRIPTION
This PR brings the workstream governance from the SIG Interoperability
repository as it is proven to be successful.

https://github.com/cdfoundation/sig-interoperability/blob/main/docs/workstream-governance.md

A future item could be to discuss making the workstream governance common
across the CDF SIGs in TOC meeting and moving the doc to TOC repo.